### PR TITLE
Fix Syntax Warning

### DIFF
--- a/uf2conv/uf2conv.py
+++ b/uf2conv/uf2conv.py
@@ -209,7 +209,7 @@ def get_drives():
                                      "FileSystem,", "DriveType"])
         for line in to_str(r).split('\n'):
             #words = re.split('\s+', line)
-            words = re.split(r'\s+', line ## / corrected by ChatGTP
+            words = re.split(r'\s+', line) ## / corrected by ChatGTP
             if len(words) >= 3 and words[1] == "2" and words[2] == "FAT":
                 drives.append(words[0])
     else:

--- a/uf2conv/uf2conv.py
+++ b/uf2conv/uf2conv.py
@@ -208,7 +208,8 @@ def get_drives():
                                      "get", "DeviceID,", "VolumeName,",
                                      "FileSystem,", "DriveType"])
         for line in to_str(r).split('\n'):
-            words = re.split('\s+', line)
+            #words = re.split('\s+', line)
+            words = re.split(r'\s+', line ## / corrected by ChatGTP
             if len(words) >= 3 and words[1] == "2" and words[2] == "FAT":
                 drives.append(words[0])
     else:


### PR DESCRIPTION
Fix: Use raw string for regex to prevent Syntax Warning for invalid escape sequence.